### PR TITLE
Include seconds in input_value

### DIFF
--- a/lib/active_admin_datetimepicker/base.rb
+++ b/lib/active_admin_datetimepicker/base.rb
@@ -28,7 +28,7 @@ module ActiveAdminDatetimepicker
 
     def input_value(input_name = nil)
       val = object.public_send(input_name || method)
-      return DateTime.new(val.year, val.month, val.day, val.hour, val.min).strftime(format) if val.is_a?(Time)
+      return DateTime.new(val.year, val.month, val.day, val.hour, val.min, val.sec).strftime(format) if val.is_a?(Time)
       val.to_s
     end
 


### PR DESCRIPTION
This preserves existing values with seconds in them instead of overwriting the seconds with 0. This is helpful if using the overrides from the [README](https://github.com/activeadmin-plugins/active_admin_datetimepicker#override-behaviour-in-initializer)
