### PR TITLE
Fix asset path for newer version of xdan-datetimepicker-rails, subsequently datetimepicker

### DIFF
--- a/active_admin_datetimepicker.gemspec
+++ b/active_admin_datetimepicker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "xdan-datetimepicker-rails", "~> 2.4"
+  spec.add_dependency "xdan-datetimepicker-rails", "~> 2.5.1"
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
 

--- a/app/assets/javascripts/active_admin_datetimepicker.js.coffee
+++ b/app/assets/javascripts/active_admin_datetimepicker.js.coffee
@@ -1,4 +1,4 @@
-#= require jquery.xdan.datetimepicker
+#= require jquery.xdan.datetimepicker.full
 
 @setupDateTimePicker = (container) ->
   defaults = {


### PR DESCRIPTION
**Related Repos**
- [xdan-datetimepicker-rails](https://github.com/shekibobo/xdan-datetimepicker-rails)
- [datetimepicker](https://github.com/xdan/datetimepicker)

After version `2.4.5` the `jquery.datetimepicker.js` received braking changes in [this commit](https://github.com/shekibobo/xdan-datetimepicker-rails/commit/fe6a632ecfe216330aafeff69049bd817a465749#diff-e7db64a705b3cca1230faac39e455fea) ( [subsequently](https://github.com/xdan/datetimepicker/commit/f910a50ffd48239216c22df1483d410f61e98c64) ) and was added `jquery.datetimepicker.full.js`. This change switches the asset path to the new `jquery.datetimepicker.full.js` and bumps the version of [xdan-datetimepicker-rails](https://github.com/shekibobo/xdan-datetimepicker-rails) to pull the latest version. 

This change request fixes issue #12 - The work around to that issue to force your app gemfile to use `gem 'xdan-datetimepicker-rails', '2.4.5'` or lower.

@Fivell please consider accepting or commenting on this pull request as currently the gem is broken when installing  `active_admin_datetimepicker` fresh. 
