### PR TITLE
Resolve compatibility issue with recent Sprockets

### DIFF
--- a/app/assets/stylesheets/active_admin_datetimepicker.scss
+++ b/app/assets/stylesheets/active_admin_datetimepicker.scss
@@ -1,4 +1,4 @@
-@import "jquery.xdan.datetimepicker";
+@import "jquery.xdan.datetimepicker.css";
 
 form.filter_form {
   .filter_form_field {


### PR DESCRIPTION
Fixes `File to import not found or unreadable: jquery.xdan.datetimepicker`.