### PR TITLE
loosen activeadmin restriction to allow 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,20 @@ language: ruby
 addons:
   chrome: stable
 
-before_install: gem install bundler -v 1.16.0.pre.3
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 
 script: bundle exec rspec spec
 
 env:
   matrix:
-    - RAILS=4.2.10 AA=1.1.0
-    - RAILS=5.1.0 AA=1.2.1
-    - RAILS=5.2.1 AA=1.3.1
-    - RAILS=5.2.1 AA=1.4.0
-    - RAILS=5.2.1 AA=2.0
+    - RAILS=4.2.0 AA=1.1.0
+    - RAILS=5.1.0 AA=1.2.0
+    - RAILS=5.2.0 AA=1.3.0
+    - RAILS=5.2.0 AA=1.4.0
+    - RAILS=5.2.0 AA=2.0.0
+
 rvm:
-  - 2.3
-  - 2.5
+  - 2.4
+  - 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - RAILS=5.1.0 AA=1.2.1
     - RAILS=5.2.1 AA=1.3.1
     - RAILS=5.2.1 AA=1.4.0
+    - RAILS=5.2.1 AA=2.0
 rvm:
   - 2.3
   - 2.5

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,10 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in active_admin_datetimepicker.gemspec
 gemspec
+
 group :test do
   default_rails_version = '5.2.1'
-  default_activeadmin_version = '1.3.1'
+  default_activeadmin_version = '2.0.0'
 
   gem 'rails', "~> #{ENV['RAILS'] || default_rails_version}"
   gem 'activeadmin', "~> #{ENV['AA'] || default_activeadmin_version}"
@@ -12,7 +13,7 @@ group :test do
   gem 'rspec-rails'
   gem 'coveralls', require: false # Test coverage website. Go to https://coveralls.io
   gem 'sass-rails'
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
   gem 'launchy'
   gem 'database_cleaner'
   gem 'capybara'

--- a/active_admin_datetimepicker.gemspec
+++ b/active_admin_datetimepicker.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "coffee-rails"
   spec.add_dependency "activeadmin", ">= 1.1", "< 3.a"
   spec.add_dependency "xdan-datetimepicker-rails", "~> 2.5.4"
 end

--- a/active_admin_datetimepicker.gemspec
+++ b/active_admin_datetimepicker.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activeadmin", "~> 1.1"
+  spec.add_dependency "activeadmin", ">= 1.1", "< 3.a"
   spec.add_dependency "xdan-datetimepicker-rails", "~> 2.5.4"
 end

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -27,9 +27,15 @@ inject_into_file "app/assets/stylesheets/active_admin.scss",
                  "@import \"active_admin_datetimepicker\";\n",
                  after: "@import \"active_admin/base\";\n"
 
-inject_into_file "app/assets/javascripts/active_admin.js.coffee",
-                 "#= require active_admin_datetimepicker\n",
-                 after: "#= require active_admin/base\n"
+if File.file?("app/assets/javascripts/active_admin.js.coffee")
+  inject_into_file "app/assets/javascripts/active_admin.js.coffee",
+                   "#= require active_admin_datetimepicker\n",
+                   after: "#= require active_admin/base\n"
+else
+  inject_into_file "app/assets/javascripts/active_admin.js",
+                  "//= require active_admin_datetimepicker\n",
+                  after: "//= require active_admin/base\n"
+end
 
 run "rm -r test"
 run "rm -r spec"


### PR DESCRIPTION
https://github.com/activeadmin/activeadmin/blob/master/CHANGELOG.md

Activeadmin 2.0 do not сontain any major changes except ruby 2.3 support drop, this gem should be fine