### PR TITLE
Add support of Formtastic::String input_html

### DIFF
--- a/lib/active_admin_datetimepicker/base.rb
+++ b/lib/active_admin_datetimepicker/base.rb
@@ -14,13 +14,14 @@ module ActiveAdminDatetimepicker
     end
 
     def input_html_options(input_name = nil, placeholder = nil)
-      options = {}
-      options[:class] = [self.options[:class], html_class].compact.join(' ')
-      options[:data] ||= input_html_data
-      options[:data].merge!(datepicker_options: datetime_picker_options)
-      options[:value] ||= input_value(input_name)
-      options[:maxlength] = 19
-      options
+      super().tap do |options|
+        options[:class] = [self.options[:class], html_class].compact.join(' ')
+        options[:data] ||= input_html_data
+        options[:data].merge!(datepicker_options: datetime_picker_options)
+        options[:value] ||= input_value(input_name)
+        options[:maxlength] = 19
+        options[:placeholder] = placeholder unless placeholder.nil?
+      end
     end
 
     def input_value(input_name = nil)

--- a/spec/filters_and_edit_form_spec.rb
+++ b/spec/filters_and_edit_form_spec.rb
@@ -38,6 +38,8 @@ describe 'authors index', type: :feature, js: true do
 
       expect(page.find('input#q_birthday_gteq').value).to start_with(date_from)
       expect(page.find('input#q_birthday_lteq').value).to start_with(date_to)
+      expect(page).to have_css('input#q_birthday_gteq[placeholder="From"]')
+      expect(page).to have_css('input#q_birthday_lteq[placeholder="To"]')
     end
   end
 
@@ -59,6 +61,7 @@ describe 'authors index', type: :feature, js: true do
     it 'can set birthday'  do
       date_birthday = Date.today.beginning_of_month.strftime("%Y-%m-%d")
       expect(page.find('#author_birthday').value).to start_with(date_birthday)
+      expect(page).to have_css('#author_birthday[placeholder="Formtastic placeholder"]')
     end
   end
 

--- a/spec/support/admin.rb
+++ b/spec/support/admin.rb
@@ -10,7 +10,7 @@ def add_author_resource(options = {}, &block)
 
       f.inputs 'General' do
         f.input :name
-        f.input :birthday, as: :date_time_picker
+        f.input :birthday, as: :date_time_picker, input_html: { placeholder: 'Formtastic placeholder' }
       end
 
       f.actions


### PR DESCRIPTION
[refs #52]

@mantoszew found the bug with range-input:
- From/To placeholder are missing

This commit aims to fix it.
And also add support of other `input_html` options to the "f.input date_time_picker".

For example:

```ruby
form do |f|
  f.input :created_at, as: :date_time_picker, input_html: { placeholder: 'Text here...' }
end
```