### PR TITLE
Fix Input HTML Value Default and Non Date Time Inputs

### DIFF
--- a/lib/active_admin_datetimepicker/base.rb
+++ b/lib/active_admin_datetimepicker/base.rb
@@ -18,20 +18,25 @@ module ActiveAdminDatetimepicker
         options[:class] = [self.options[:class], html_class].compact.join(' ')
         options[:data] ||= input_html_data
         options[:data].merge!(datepicker_options: datetime_picker_options)
-        options[:value] = input_value(input_name)
+        options[:value] = input_value(input_name, options)
         options[:maxlength] = 19
         options[:placeholder] = placeholder unless placeholder.nil?
       end
     end
 
     def input_value(input_name = nil)
+      return options[:value] if options[:value].present?
+
       val = object.public_send(input_name || method)
-      if val.nil?
+
+      return nil if val.nil?
+
+      if column.type == :date
         val
-      elsif column.type == :date
-        val
-      else
+      elsif column.type == :datetime
         DateTime.new(val.year, val.month, val.day, val.hour, val.min, val.sec).strftime(format)
+      else
+        val.to_s
       end
     end
 

--- a/spec/filters_and_edit_form_spec.rb
+++ b/spec/filters_and_edit_form_spec.rb
@@ -81,6 +81,7 @@ describe 'authors index', type: :feature, js: true do
       date_birthday = Date.today.beginning_of_month.strftime("%Y-%m-%d")
       expect(page.find('#author_birthday').value).to start_with(date_birthday)
       expect(page).to have_css('#author_birthday[placeholder="Formtastic placeholder"]')
+      expect(page).to have_css('#author_birthday[value="Formtastic value"]')
     end
   end
 

--- a/spec/support/admin.rb
+++ b/spec/support/admin.rb
@@ -11,7 +11,7 @@ def add_author_resource(options = {}, &block)
 
       f.inputs 'General' do
         f.input :name
-        f.input :birthday, as: :date_time_picker, input_html: { placeholder: 'Formtastic placeholder' }
+        f.input :birthday, as: :date_time_picker, input_html: { placeholder: 'Formtastic placeholder', value: 'Formtastic Value' }
       end
 
       f.actions


### PR DESCRIPTION
This PR does two things that have regressed in `active_admin_datetimepicker` in 0.7.2.

The first issue is that we could previously pass in integers, String, etc for a model attribute and the date picker will still render. With this change however https://github.com/activeadmin-plugins/active_admin_datetimepicker/blob/master/lib/active_admin_datetimepicker/base.rb#L34, we now get an error that `min` is not a method on the value. It may seem wonky that we would want to render a date picker for a non date field but that was our use case. We'd massage the value pack to the integer in the AA controller. Perhaps this should be a configuration with an explicit warning or raise, vs attempting to call `min` when it will fail.

The second seems like a straight up bug, with the `input_html: { value: X }` no longer being set in the date picker.

This PR attempts to fix both.