### PR TITLE
Replace chromedriver-helper with webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ group :test do
   gem 'launchy'
   gem 'database_cleaner'
   gem 'capybara'
-  gem 'selenium-webdriver'
-  gem 'chromedriver-helper'
+  gem 'webdrivers'
   gem 'byebug'
 end


### PR DESCRIPTION
I saw https://github.com/activeadmin-plugins/active_admin_datetimepicker/issues/62 had a help wanted tag so I figured I'd take a crack at it.