### PR TITLE
Fix compatibility with ActiveAdmin 2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 Gemfile.lock
 coverage/
 spec/rails/rails-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,10 @@ script: bundle exec rspec spec
 
 env:
   matrix:
-    - RAILS=4.2.0 AA=1.1.0
-    - RAILS=5.1.0 AA=1.2.0
-    - RAILS=5.2.0 AA=1.3.0
     - RAILS=5.2.0 AA=1.4.0
     - RAILS=5.2.0 AA=2.0.0
+    - RAILS=6.0.0 AA=2.6.0
 
 rvm:
-  - 2.4
+  - 2.5
   - 2.6

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  default_rails_version = '5.2.1'
-  default_activeadmin_version = '2.0.0'
+  default_rails_version = '6.0.0'
+  default_activeadmin_version = '2.6.0'
 
   gem 'rails', "~> #{ENV['RAILS'] || default_rails_version}"
   gem 'activeadmin', "~> #{ENV['AA'] || default_activeadmin_version}"
@@ -14,7 +14,7 @@ group :test do
   gem 'rspec-rails'
   gem 'coveralls', require: false # Test coverage website. Go to https://coveralls.io
   gem 'sass-rails'
-  gem 'sqlite3', '~> 1.3.6'
+  gem 'sqlite3', '~> 1.4.0'
   gem 'launchy'
   gem 'database_cleaner'
   gem 'capybara'

--- a/lib/active_admin_datetimepicker/inputs/filters/date_time_range_input.rb
+++ b/lib/active_admin_datetimepicker/inputs/filters/date_time_range_input.rb
@@ -11,6 +11,12 @@ module ActiveAdmin
           end
         end
 
+        # This method is for compatibility for ActiveAdmin 2.6
+        def input_html_options_for(input_name, placeholder)
+          super.merge placeholder: placeholder,
+                      value: input_value(input_name)
+        end
+
         def gt_input_name
           column && column.type == :date ? super : "#{method}_gteq_datetime_picker"
         end

--- a/spec/filter_form_spec.rb
+++ b/spec/filter_form_spec.rb
@@ -71,6 +71,9 @@ describe 'authors index', type: :feature, js: true do
         page.find('.xdsoft_datetimepicker', visible: true)
             .find('.xdsoft_timepicker.active .xdsoft_time.xdsoft_current').click
 
+        @value_from = page.find('#q_created_at_gteq_datetime_picker').value
+        @value_to = page.find('#q_created_at_lteq_datetime_picker').value
+
         page.find('#sidebar input[type=submit]').click
         page.has_css?('h4', text: 'Current filters:')
       end
@@ -80,9 +83,13 @@ describe 'authors index', type: :feature, js: true do
         expect(page).not_to have_text('from-the-future')
       end
 
-      it 'submit filter form' do
+      it 'input#value and placeholder is the same as before form submit' do
         # created_at(Timestamp type) should contain Hours:Minutes, as selected before submit
-        expect(page.find('#q_created_at_gteq_datetime_picker').value).to match(/\A\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}\z/)
+        expect(page.find('#q_created_at_gteq_datetime_picker').value).to match(@value_from)
+        expect(page.find('#q_created_at_lteq_datetime_picker').value).to match(@value_to)
+
+        expect(page).to have_css('#q_created_at_gteq_datetime_picker[placeholder=From]')
+        expect(page).to have_css('#q_created_at_lteq_datetime_picker[placeholder=To]')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ end
 require 'active_model'
 # require ActiveRecord to ensure that Ransack loads correctly
 require 'active_record'
+require 'action_view'
 require 'active_admin'
 ActiveAdmin.application.load_paths = [ENV['RAILS_ROOT'] + "/app/admin"]
 require ENV['RAILS_ROOT'] + '/config/environment.rb'


### PR DESCRIPTION
This PR fixes #65, which is actually a broken compatibility with ActiveAdmin 2.6

* [x] Remove all ActiveAdmin less then 1.4 (all of them were identical, according to [date_range_input.rb](https://github.com/activeadmin/activeadmin/blob/v1.4.0/lib/active_admin/inputs/filters/date_range_input.rb)
* [x] Fix compatibility  with ActieAdmin 2.6+ and remain compatible with older versions
* [x] Add new specs to cover the fix