### PR TITLE
activeadmin v2.10.x compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
             activeadmin: '1.4.0'
           - rails: '6.0.0'
             activeadmin: '2.0.0'
+        include:
+          - rails: '6.0.0'
+            ruby: 2.6
+            activeadmin: '2.10.0'
     env:
       RAILS: ${{ matrix.rails }}
       AA: ${{ matrix.activeadmin }}

--- a/app/assets/stylesheets/active_admin_datetimepicker.scss
+++ b/app/assets/stylesheets/active_admin_datetimepicker.scss
@@ -1,3 +1,8 @@
+// activeadmin v2.10.x compatibility
+$sidebar-inner-content-width: $sidebar-width - ($section-padding * 2) !default;
+$filter-field-seperator-width: 12px !default;
+$side-by-side-filter-input-width: ($sidebar-inner-content-width * 0.5) - ($text-input-horizontal-padding * 2) - $filter-field-seperator-width !default;
+
 form.filter_form {
   .filter_form_field {
     &.filter_date_time_range {


### PR DESCRIPTION
the latest active_admin_datetimepicker v0.7.4 is not compatible with activeadmin v2.10.x, but compatible with v2.11.0