### PR TITLE
Fix parsing datetime input values

### DIFF
--- a/lib/active_admin_datetimepicker/base.rb
+++ b/lib/active_admin_datetimepicker/base.rb
@@ -26,13 +26,13 @@ module ActiveAdminDatetimepicker
 
     def input_value(input_name = nil)
       val = object.public_send(input_name || method)
-      if val.nil?
-        val
-      elsif column.type == :date
-        val
-      else
-        DateTime.new(val.year, val.month, val.day, val.hour, val.min, val.sec).strftime(format)
-      end
+      val.is_a?(Date) ? val : parse_datetime(val)
+    end
+
+    def parse_datetime(val)
+      DateTime.parse(val.to_s).strftime(format)
+    rescue ArgumentError
+      nil
     end
 
     def datetime_picker_options

--- a/spec/support/admin.rb
+++ b/spec/support/admin.rb
@@ -5,6 +5,7 @@ def add_author_resource(options = {}, &block)
 
     filter :birthday, as: :date_time_range
     filter :created_at, as: :date_time_range
+    filter :last_seen_at, as: :date_time_range
 
     form do |f|
       f.semantic_errors *f.object.errors.keys

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -4,7 +4,7 @@ generate :model, 'author name:string{10}:uniq last_name:string birthday:date'
 generate :model, 'post title:string:uniq body:text author:references'
 
 #Add validation
-inject_into_file "app/models/author.rb", "  validates_presence_of :name\n  validates_uniqueness_of :last_name\n", after: "Base\n"
+inject_into_file "app/models/author.rb", "  validates_presence_of :name\n  validates_uniqueness_of :last_name\n\n  attr_accessor :last_seen_at\n  ransacker :last_seen_at do\n    Arel.sql('updated_at')\n  end\n", after: "ApplicationRecord\n"
 inject_into_file "app/models/post.rb", "   validates_presence_of :author\n", after: ":author\n"
 
 # Configure default_url_options in test environment


### PR DESCRIPTION
Normalizing working with Date & Time input values to make possible searching by virtual attributes or resources based not only on `ActiveRecord`, for example,  based on `ActiveModel`, `OpenStruct` etc.. Virtual attributes don't have a typecasting  (column&type properties) - the gem just crashed when trying to work with attributes like just a formatted string of DateTime.