### PR TITLE
Add NPM module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Gem Version](https://badge.fury.io/rb/active_admin_datetimepicker.svg)](http://badge.fury.io/rb/active_admin_datetimepicker)
+[![NPM Version](https://badge.fury.io/js/active_admin_datetimepicker.svg)](https://badge.fury.io/js/active_admin_datetimepicker)
+[![npm](https://img.shields.io/npm/dm/active_admin_datetimepicker.svg)](https://www.npmjs.com/package/@activeadmin-plugins/active_admin_datetimepicker)
 [![Build Status](https://img.shields.io/travis/activeadmin-plugins/active_admin_datetimepicker.svg)](https://travis-ci.org/activeadmin-plugins/active_admin_datetimepicker)
 [![Coverage](https://coveralls.io/repos/activeadmin-plugins/active_admin_datetimepicker/badge.svg?branch=master)](https://coveralls.io/r/activeadmin-plugins/active_admin_datetimepicker)
 
@@ -24,7 +26,8 @@ Or install it yourself as:
 
     $ gem install active_admin_datetimepicker
 
-Add the following line into `app/assets/stylesheets/active_admin.css.scss`:
+##### Using assets via Sprockets
+Add the following line into `app/assets/stylesheets/active_admin.scss`:
 
 ```css
 @import "active_admin_datetimepicker";
@@ -36,6 +39,38 @@ Add the following line into `app/assets/javascripts/active_admin.js`:
 //= require active_admin_datetimepicker
 ```
 
+##### Using assets via Webpacker (or any other assets bundler) as a NPM module (Yarn package)
+
+Execute:
+
+    $ npm i @activeadmin-plugins/active_admin_datetimepicker
+
+Or
+
+    $ yarn add @activeadmin-plugins/active_admin_datetimepicker
+
+Or add manually to `package.json`:
+
+```
+"dependencies": {
+  "@activeadmin-plugins/active_admin_datetimepicker": "0.7.4"
+}
+```
+and execute:
+
+    $ yarn
+
+Add the following line into `app/assets/javascripts/active_admin.js`:
+
+```javascript
+import '@activeadmin-plugins/active_admin_datetimepicker';
+```
+
+Add the following line into `app/assets/stylesheets/active_admin.scss`:
+
+```css
+@import '@activeadmin-plugins/active_admin_datetimepicker';
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Or add manually to `package.json`:
 
 ```
 "dependencies": {
-  "@activeadmin-plugins/active_admin_datetimepicker": "0.7.4"
+  "@activeadmin-plugins/active_admin_datetimepicker": "1.0.0"
 }
 ```
 and execute:

--- a/lib/active_admin_datetimepicker/version.rb
+++ b/lib/active_admin_datetimepicker/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdminDatetimepicker
-  VERSION = "0.7.4"
+  VERSION = "1.0.0"
 end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@activeadmin-plugins/active_admin_datetimepicker",
+  "version": "0.7.4",
+  "description": "Integrate jQuery xdan datetimepicker plugin to ActiveAdmin",
+  "main": "src/active_admin_datetimepicker.js",
+  "style": "src/active_admin_datetimepicker.scss",
+  "author": "Igor Fedoronchuk <fedoronchuk@gmail.com>",
+  "license": "MIT",
+  "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/activeadmin-plugins/active_admin_datetimepicker.git"
+  },
+  "bugs": {
+    "url": "https://github.com/activeadmin-plugins/active_admin_datetimepicker/issues"
+  },
+  "homepage": "https://github.com/activeadmin-plugins/active_admin_datetimepicker#readme",
+  "keywords": [
+    "active",
+    "admin",
+    "datetimepicker"
+  ],
+  "files": [
+    "src/**/*",
+    "!src/*.bak"
+  ],
+  "scripts": {
+    "prepare_src": "rm -rf src && cp -R app/assets/javascripts/ src && cp -R app/assets/stylesheets/ src",
+    "prepare_import": "sed -i.bak 1s/'\\/\\/\\= require vendor\\/jquery.datetimepicker.full'/\"import '.\\/vendor\\/jquery.datetimepicker.full';\"/ src/active_admin_datetimepicker.js",
+    "prepublishOnly": "npm run prepare_src && npm run prepare_import"
+  },
+  "dependencies": {
+    "jquery-mousewheel": ">= 3.1.13"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activeadmin-plugins/active_admin_datetimepicker",
-  "version": "0.7.4",
+  "version": "1.0.0",
   "description": "Integrate jQuery xdan datetimepicker plugin to ActiveAdmin",
   "main": "src/active_admin_datetimepicker.js",
   "style": "src/active_admin_datetimepicker.scss",


### PR DESCRIPTION
This PR adds support to use this repo as an NPM/Yarn package so we can use it with Webpacker or any other assets bundler.
I implemented this so it uses the same source files as the Rails gem so any change in the JS and CSS is available in both cases. I didn't change the Rails gem-related code this same repo can be used in both ways.

After pack&publish NPM module has minimum files and should look like:
![NPM](https://user-images.githubusercontent.com/22831505/163529488-6d8c3f3a-a74c-4369-a8bc-224df78f3fb0.png)