### PR TITLE
update ruby/rails/activeadmin matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           - ruby: '3.2.0'
             rails: '7.1.0'
             activeadmin: '3.2.0'
+          - ruby: '3.3.0'
+            rails: '7.1.0'
+            activeadmin: '3.2.0'
     env:
       RAILS: ${{ matrix.rails }}
       AA: ${{ matrix.activeadmin }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,21 @@ jobs:
     strategy:
       matrix:
         include:
-          - ruby: 2.6
-            rails: '6.0.2'
-            activeadmin: '2.6.0'
-          - ruby: 2.7
-            rails: '7.0.8'
-            activeadmin: '2.13.0'
-          - ruby: 3.2
+          - ruby: '3.0.0'
+            rails: '6.1.0'
+            activeadmin: '2.14.0'
+          - ruby: '3.0.0'
+            rails: '6.1.0'
+            activeadmin: '3.0.0'
+          - ruby: '3.0.0'
+            rails: '7.0.0'
+            activeadmin: '3.0.0'
+          - ruby: '3.1.0'
             rails: '7.1.0'
             activeadmin: '3.1.0'
+          - ruby: '3.2.0'
+            rails: '7.1.0'
+            activeadmin: '3.2.0'
     env:
       RAILS: ${{ matrix.rails }}
       AA: ${{ matrix.activeadmin }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,25 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby:
-          - 3.0
-          - 3.1
-          - 3.2
-        rails:
-          - '6.1.0'
-          - '7.0.0'
-          - '7.1.0'
-        activeadmin:
-          - '3.0.0'
-          - '3.1.0'
-        exclude:
-          - rails: '7.1.0'
-            activeadmin: '3.0.0'
+        include:
+          - ruby: 2.6
+            rails: '6.0.2'
+            activeadmin: '2.6.0'
+          - ruby: 2.7
+            rails: '7.0.8'
+            activeadmin: '2.13.0'
+          - ruby: 3.2
+            rails: '7.1.0'
+            activeadmin: '3.1.0'
     env:
       RAILS: ${{ matrix.rails }}
       AA: ${{ matrix.activeadmin }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,25 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.5
-          - 2.6
+          - 3.0
+          - 3.1
+          - 3.2
         rails:
-          - '5.2.0'
-          - '6.0.0'
+          - '6.1.0'
+          - '7.0.0'
+          - '7.1.0'
         activeadmin:
-          - '2.0.0'
-          - '2.6.0'
+          - '3.0.0'
+          - '3.1.0'
         exclude:
-          - rails: '5.2.0'
-            activeadmin: '2.6.0'
-          - rails: '6.0.0'
-            activeadmin: '2.0.0'
+          - rails: '7.1.0'
+            activeadmin: '3.0.0'
     env:
       RAILS: ${{ matrix.rails }}
       AA: ${{ matrix.activeadmin }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,25 +10,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - ruby: '3.0.0'
-            rails: '6.1.0'
+        ruby:
+          - '3.0.0'
+          - '3.1.0'
+          - '3.2.0'
+          - '3.3.0'
+        rails:
+          - '6.1.0'
+          - '7.0.0'
+          - '7.1.0'
+        activeadmin:
+          - '2.14.0'
+          - '3.0.0'
+          - '3.1.0'
+          - '3.2.0'
+        exclude:
+          - rails: '7.1.0'
             activeadmin: '2.14.0'
-          - ruby: '3.0.0'
-            rails: '6.1.0'
+          - rails: '7.1.0'
             activeadmin: '3.0.0'
-          - ruby: '3.0.0'
-            rails: '7.0.0'
-            activeadmin: '3.0.0'
-          - ruby: '3.1.0'
-            rails: '7.1.0'
-            activeadmin: '3.1.0'
-          - ruby: '3.2.0'
-            rails: '7.1.0'
-            activeadmin: '3.2.0'
-          - ruby: '3.3.0'
-            rails: '7.1.0'
-            activeadmin: '3.2.0'
     env:
       RAILS: ${{ matrix.rails }}
       AA: ${{ matrix.activeadmin }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,15 +4,15 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  default_rails_version = '7.0.0'
-  default_activeadmin_version = '3.0.0'
+  default_rails_version = '7.1.0'
+  default_activeadmin_version = '3.1.0'
 
   gem 'rails', "~> #{ENV['RAILS'] || default_rails_version}"
   gem 'activeadmin', "~> #{ENV['AA'] || default_activeadmin_version}"
 
   gem 'sprockets-rails'
   gem 'rspec-rails'
-  gem 'coveralls_reborn', require: false # Test coverage website. Go to https://coveralls.io
+  gem 'coveralls_reborn', require: false
   gem 'sass-rails'
   gem 'sqlite3', '~> 1.4.0'
   gem 'launchy'

--- a/Gemfile
+++ b/Gemfile
@@ -4,15 +4,15 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  default_rails_version = '6.0.0'
-  default_activeadmin_version = '2.6.0'
+  default_rails_version = '7.0.0'
+  default_activeadmin_version = '3.0.0'
 
   gem 'rails', "~> #{ENV['RAILS'] || default_rails_version}"
   gem 'activeadmin', "~> #{ENV['AA'] || default_activeadmin_version}"
 
-  gem 'sprockets-rails', '3.0.4'
+  gem 'sprockets-rails'
   gem 'rspec-rails'
-  gem 'coveralls', require: false # Test coverage website. Go to https://coveralls.io
+  gem 'coveralls_reborn', require: false # Test coverage website. Go to https://coveralls.io
   gem 'sass-rails'
   gem 'sqlite3', '~> 1.4.0'
   gem 'launchy'
@@ -20,4 +20,5 @@ group :test do
   gem 'capybara'
   gem 'webdrivers'
   gem 'byebug'
+  gem 'webrick', require: false
 end

--- a/active_admin_datetimepicker.gemspec
+++ b/active_admin_datetimepicker.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activeadmin", ">= 2.0", "<= 3.1"
+  spec.add_dependency "activeadmin", ">= 2.14.0", "< 4.0"
 end

--- a/active_admin_datetimepicker.gemspec
+++ b/active_admin_datetimepicker.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activeadmin", ">= 2.0", "< 3.a"
+  spec.add_dependency "activeadmin", ">= 3.0.0"
 end

--- a/active_admin_datetimepicker.gemspec
+++ b/active_admin_datetimepicker.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activeadmin", ">= 3.0.0"
+  spec.add_dependency "activeadmin", ">= 2.0", "<= 3.1"
 end

--- a/spec/filter_form_spec.rb
+++ b/spec/filter_form_spec.rb
@@ -49,11 +49,11 @@ describe 'authors index', type: :feature, js: true do
       before do
         Author.create!(name: "Ren",
                        last_name: "from-20-day-of-month",
-                       created_at: (Time.now.change(day: 20) - 1.hour).to_fs(:db))
+                       created_at: (Time.now.change(day: 20) - 1.hour).to_formatted_s(:db))
 
         Author.create!(name: "Rey",
                        last_name: "from-the-future",
-                       created_at: (Time.now.change(day: 20) + 2.hours).to_fs(:db))
+                       created_at: (Time.now.change(day: 20) + 2.hours).to_formatted_s(:db))
 
         # chose 01 and 20 day of the current month
 
@@ -94,8 +94,8 @@ describe 'authors index', type: :feature, js: true do
     end
 
     context 'filter by virtual attribute last_seen_at - without column&type properties (search by updated_at)' do
-      let!(:first_author) { Author.create!(name: 'Ren', last_name: 'current', updated_at: Time.now.to_fs(:db)) }
-      let!(:second_author) { Author.create!(name: 'Rey', last_name: 'future', updated_at: 21.days.from_now.to_fs(:db)) }
+      let!(:first_author) { Author.create!(name: 'Ren', last_name: 'current', updated_at: Time.now.to_formatted_s(:db)) }
+      let!(:second_author) { Author.create!(name: 'Rey', last_name: 'future', updated_at: 21.days.from_now.to_formatted_s(:db)) }
 
       before do
         # chose 01 and 20 day of the current month

--- a/spec/filter_form_spec.rb
+++ b/spec/filter_form_spec.rb
@@ -94,10 +94,11 @@ describe 'authors index', type: :feature, js: true do
     end
 
     context 'filter by virtual attribute last_seen_at - without column&type properties (search by updated_at)' do
-      let!(:first_author) { Author.create!(name: 'Ren', last_name: 'current', updated_at: Time.now.to_formatted_s(:db)) }
-      let!(:second_author) { Author.create!(name: 'Rey', last_name: 'future', updated_at: 21.days.from_now.to_formatted_s(:db)) }
-
       before do
+        Author.create!(name: 'Ren', last_name: 'One', updated_at: (Time.now.change(day: 1) + 1.hour).to_formatted_s(:db))
+        Author.create!(name: 'Ron', last_name: 'Two', updated_at: (Time.now.change(day: 20) - 1.hour).to_formatted_s(:db))
+        Author.create!(name: 'Rey', last_name: 'future', updated_at: Time.now.change(day: 21).to_formatted_s(:db))
+
         # chose 01 and 20 day of the current month
         page.find('input#q_last_seen_at_gteq_datetime_picker').click
         page.find('.xdsoft_datetimepicker', visible: true)
@@ -118,9 +119,10 @@ describe 'authors index', type: :feature, js: true do
         page.has_css?('h4', text: 'Current filters:')
       end
 
-      it 'should filter records properly' do
-        expect(page).to have_text(first_author.name)
-        expect(page).not_to have_text(second_author.name)
+      it 'finds the first and second authors, but not the third one, because he is outside of the filtered dates' do
+        expect(page).to have_text('Ren')
+        expect(page).to have_text('Ron')
+        expect(page).not_to have_text('Rey')
       end
 
       it 'input#value and placeholder is the same as before form submit' do

--- a/spec/filter_form_spec.rb
+++ b/spec/filter_form_spec.rb
@@ -49,11 +49,11 @@ describe 'authors index', type: :feature, js: true do
       before do
         Author.create!(name: "Ren",
                        last_name: "from-20-day-of-month",
-                       created_at: (Time.now.change(day: 20) - 1.hour).to_s(:db))
+                       created_at: (Time.now.change(day: 20) - 1.hour).to_fs(:db))
 
         Author.create!(name: "Rey",
                        last_name: "from-the-future",
-                       created_at: (Time.now.change(day: 20) + 2.hours).to_s(:db))
+                       created_at: (Time.now.change(day: 20) + 2.hours).to_fs(:db))
 
         # chose 01 and 20 day of the current month
 
@@ -94,8 +94,8 @@ describe 'authors index', type: :feature, js: true do
     end
 
     context 'filter by virtual attribute last_seen_at - without column&type properties (search by updated_at)' do
-      let!(:first_author) { Author.create!(name: 'Ren', last_name: 'current', updated_at: Time.now.to_s(:db)) }
-      let!(:second_author) { Author.create!(name: 'Rey', last_name: 'future', updated_at: 21.days.from_now.to_s(:db)) }
+      let!(:first_author) { Author.create!(name: 'Ren', last_name: 'current', updated_at: Time.now.to_fs(:db)) }
+      let!(:second_author) { Author.create!(name: 'Rey', last_name: 'future', updated_at: 21.days.from_now.to_fs(:db)) }
 
       before do
         # chose 01 and 20 day of the current month

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ require 'rails'
 ENV['RAILS'] = Rails.version
 ENV['RAILS_ROOT'] = File.expand_path("../rails/rails-#{ENV['RAILS']}", __FILE__)
 # Create the test app if it doesn't exists
-unless File.exists?(ENV['RAILS_ROOT'])
+unless File.exist?(ENV['RAILS_ROOT'])
   system 'rake setup'
 end
 

--- a/spec/support/admin.rb
+++ b/spec/support/admin.rb
@@ -8,7 +8,7 @@ def add_author_resource(options = {}, &block)
     filter :last_seen_at, as: :date_time_range
 
     form do |f|
-      f.semantic_errors *f.object.errors.keys
+      f.semantic_errors(*f.object.errors.attribute_names)
 
       f.inputs 'General' do
         f.input :name

--- a/spec/support/admin.rb
+++ b/spec/support/admin.rb
@@ -1,6 +1,7 @@
 def add_author_resource(options = {}, &block)
-
   ActiveAdmin.register Author do
+    permit_params :name, :birthday
+
     config.filters = true
 
     filter :birthday, as: :date_time_range
@@ -8,7 +9,7 @@ def add_author_resource(options = {}, &block)
     filter :last_seen_at, as: :date_time_range
 
     form do |f|
-      f.semantic_errors(*f.object.errors.attribute_names)
+      f.semantic_errors
 
       f.inputs 'General' do
         f.input :name
@@ -18,6 +19,6 @@ def add_author_resource(options = {}, &block)
       f.actions
     end
   end
-  Rails.application.reload_routes!
 
+  Rails.application.reload_routes!
 end

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -3,8 +3,8 @@
 generate :model, 'author name:string{10}:uniq last_name:string birthday:date'
 generate :model, 'post title:string:uniq body:text author:references'
 
-#Add validation
-inject_into_file "app/models/author.rb", "  validates_presence_of :name\n  validates_uniqueness_of :last_name\n\n  attr_accessor :last_seen_at\n  ransacker :last_seen_at do\n    Arel.sql('updated_at')\n  end\n", after: "ApplicationRecord\n"
+# Add validation
+inject_into_file "app/models/author.rb", "  validates_presence_of :name\n  validates_uniqueness_of :last_name\n\n  attr_accessor :last_seen_at\n  ransacker :last_seen_at do\n    Arel.sql('updated_at')\n  end\n  def self.ransackable_attributes(auth_object = nil)\n    attribute_names\n  end\n  def self.ransackable_associations(auth_object = nil)\n    []\n  end\n", after: "ApplicationRecord\n"
 inject_into_file "app/models/post.rb", "   validates_presence_of :author\n", after: ":author\n"
 
 # Configure default_url_options in test environment

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -31,6 +31,14 @@ inject_into_file "app/models/author.rb", after: "ApplicationRecord\n" do
   validates_presence_of :name
   validates_uniqueness_of :last_name
 
+  def self.ransackable_attributes(auth_object=nil)
+    if respond_to?(:authorizable_ransackable_attributes)
+      authorizable_ransackable_attributes
+    else
+      %w(birthday created_at last_seen_at updated_at)
+    end
+  end
+
   attr_accessor :last_seen_at
 
   ransacker :last_seen_at do


### PR DESCRIPTION
- remove ruby 2.5, 2.6 support
- add ruby 3.0, 3.1, 3.2, 3.3 support
- remove rails 5.2, 6.0 support
- add rails 6.1, 7.0, 7.1 support
- remove activeadmin 2.0, 2.6 support
- add activeadmin 2.14, 3.0, 3.1, 3.2 support

ActiveAdmin <= 3.0 is incompatible with Rails >= 7.1, due to conflict with railties

