### PR TITLE
Drop EOL versions, switch to Cuprite, modernize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,33 +2,26 @@ name: CI
 on:
   pull_request:
   push:
-    branches:
-      - master
+    branches: [master]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   test:
-    name: Tests with Ruby ${{ matrix.ruby }} Rails ${{ matrix.rails }} Active Admin ${{ matrix.activeadmin }}
+    name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }} / AA ${{ matrix.activeadmin }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby:
-          - '3.0.0'
-          - '3.1.0'
-          - '3.2.0'
-          - '3.3.0'
-        rails:
-          - '6.1.0'
-          - '7.0.0'
-          - '7.1.0'
-        activeadmin:
-          - '2.14.0'
-          - '3.0.0'
-          - '3.1.0'
-          - '3.2.0'
+        ruby: ['3.2', '3.3', '3.4']
+        rails: ['7.1.0', '7.2.0', '8.0.0']
+        activeadmin: ['3.2.0', '3.3.0', '3.4.0', '3.5.1']
         exclude:
-          - rails: '7.1.0'
-            activeadmin: '2.14.0'
-          - rails: '7.1.0'
-            activeadmin: '3.0.0'
+          - rails: '8.0.0'
+            activeadmin: '3.2.0'
     env:
       RAILS: ${{ matrix.rails }}
       AA: ${{ matrix.activeadmin }}
@@ -37,8 +30,62 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - name: Run tests
+        run: bundle exec rspec spec
+
+      - name: Generate badge.json
+        if: matrix.ruby == '3.4' && matrix.rails == '8.0.0' && matrix.activeadmin == '3.5.1'
         run: |
-          gem install bundler -v '< 2'
-          bundle install
-          bundle exec rspec spec
+          LAST_RUN="coverage/.last_run.json"
+          if [ ! -f "$LAST_RUN" ]; then
+            mkdir -p badge
+            echo '{"schemaVersion":1,"label":"coverage","message":"unknown","color":"lightgrey"}' > badge/badge.json
+            exit 0
+          fi
+          PERCENT=$(ruby -rjson -e "puts JSON.parse(File.read('$LAST_RUN')).dig('result','line').round(1)")
+          PERCENT_NUM=$(ruby -rjson -e "puts JSON.parse(File.read('$LAST_RUN')).dig('result','line')")
+          if ruby -e "exit(($PERCENT_NUM >= 90) ? 0 : 1)"; then COLOR="brightgreen"
+          elif ruby -e "exit(($PERCENT_NUM >= 75) ? 0 : 1)"; then COLOR="green"
+          elif ruby -e "exit(($PERCENT_NUM >= 60) ? 0 : 1)"; then COLOR="yellow"
+          else COLOR="red"; fi
+          mkdir -p badge
+          echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${PERCENT}%\",\"color\":\"${COLOR}\"}" > badge/badge.json
+
+      - name: Upload badge artifact
+        if: matrix.ruby == '3.4' && matrix.rails == '8.0.0' && matrix.activeadmin == '3.5.1'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-badge
+          path: badge
+
+  deploy-coverage:
+    needs: test
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Download coverage badge
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-badge
+          path: .
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,24 +1,20 @@
 source 'https://rubygems.org'
-
-# Specify your gem's dependencies in active_admin_datetimepicker.gemspec
 gemspec
 
+default_rails_version = '7.1.0'
+default_activeadmin_version = '3.2.0'
+
+gem 'rails', "~> #{ENV['RAILS'] || default_rails_version}"
+gem 'activeadmin', "~> #{ENV['AA'] || default_activeadmin_version}"
+gem 'sprockets-rails'
+gem 'sass-rails'
+
 group :test do
-  default_rails_version = '7.1.0'
-  default_activeadmin_version = '3.1.0'
-
-  gem 'rails', "~> #{ENV['RAILS'] || default_rails_version}"
-  gem 'activeadmin', "~> #{ENV['AA'] || default_activeadmin_version}"
-
-  gem 'sprockets-rails'
+  gem 'simplecov', require: false
   gem 'rspec-rails'
-  gem 'coveralls_reborn', require: false
-  gem 'sass-rails'
-  gem 'sqlite3', '~> 1.4.0'
-  gem 'launchy'
+  gem 'sqlite3', '~> 2.0'
   gem 'database_cleaner'
   gem 'capybara'
-  gem 'webdrivers'
-  gem 'byebug'
+  gem 'cuprite'
   gem 'webrick', require: false
 end

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Adds XDSoft's DateTime picker as a `date_time_picker` input for forms, and `date_time_range` for filters.
 
-![ActiveAdminDatetimepicker](https://raw.githubusercontent.com/ActiveAdminPlugins/activeadmin_datetimepicker/master/screen/screen.png "ActiveAdminDatetimepicker")
+![ActiveAdminDatetimepicker](https://raw.githubusercontent.com/activeadmin-plugins/active_admin_datetimepicker/master/screen/screen.png "ActiveAdminDatetimepicker")
 
 ## Installation
 
@@ -39,7 +39,7 @@ Add the following line into `app/assets/javascripts/active_admin.js`:
 //= require active_admin_datetimepicker
 ```
 
-##### Using assets via Webpacker (or any other assets bundler) as a NPM module (Yarn package)
+##### Using assets via NPM/Yarn
 
 Execute:
 
@@ -53,7 +53,7 @@ Or add manually to `package.json`:
 
 ```
 "dependencies": {
-  "@activeadmin-plugins/active_admin_datetimepicker": "1.0.0"
+  "@activeadmin-plugins/active_admin_datetimepicker": "latest"
 }
 ```
 and execute:
@@ -121,7 +121,7 @@ See [the datetimepicker documentation for more details](http://xdsoft.net/jqplug
 
 ## Contributing
 
-1. Fork it ( https://github.com/activeadmin-plugins/activeadmin_datetimepicker/fork )
+1. Fork it ( https://github.com/activeadmin-plugins/active_admin_datetimepicker/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Gem Version](https://badge.fury.io/rb/active_admin_datetimepicker.svg)](http://badge.fury.io/rb/active_admin_datetimepicker)
 [![NPM Version](https://badge.fury.io/js/@activeadmin-plugins%2Factive_admin_datetimepicker.svg)](https://badge.fury.io/js/@activeadmin-plugins%2Factive_admin_datetimepicker)
 ![npm](https://img.shields.io/npm/dm/@activeadmin-plugins/active_admin_datetimepicker)
-[![Build Status](https://img.shields.io/travis/activeadmin-plugins/active_admin_datetimepicker.svg)](https://travis-ci.org/activeadmin-plugins/active_admin_datetimepicker)
-[![Coverage](https://coveralls.io/repos/activeadmin-plugins/active_admin_datetimepicker/badge.svg?branch=master)](https://coveralls.io/r/activeadmin-plugins/active_admin_datetimepicker)
+[![CI](https://github.com/activeadmin-plugins/active_admin_datetimepicker/actions/workflows/ci.yml/badge.svg)](https://github.com/activeadmin-plugins/active_admin_datetimepicker/actions/workflows/ci.yml)
+![Coverage](https://img.shields.io/endpoint?url=https://activeadmin-plugins.github.io/active_admin_datetimepicker/badge.json)
 
 # ActiveAdminDatetimepicker
 

--- a/active_admin_datetimepicker.gemspec
+++ b/active_admin_datetimepicker.gemspec
@@ -14,10 +14,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/activeadmin-plugins/activeadmin_datetimepicker"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = '>= 3.1.0'
+
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activeadmin", ">= 2.14.0", "< 4.0"
+  spec.add_dependency "activeadmin", ">= 3.0", "< 4.0"
 end

--- a/spec/edit_form_spec.rb
+++ b/spec/edit_form_spec.rb
@@ -12,11 +12,12 @@ describe 'authors index', type: :feature, js: true do
 
     before do
       page.find('#author_birthday').click
+      sleep 0.3
 
-      page.find('.xdsoft_datetimepicker', visible: true)
-          .find('.xdsoft_calendar td.xdsoft_date[data-date="1"]').click
-      page.find('.xdsoft_datetimepicker', visible: true)
-          .find('.xdsoft_timepicker.active .xdsoft_time.xdsoft_current').click
+      picker = page.find('.xdsoft_datetimepicker', visible: true)
+      picker.find('.xdsoft_calendar td.xdsoft_date[data-date="1"]', match: :first).click
+      sleep 0.2
+      picker.find('.xdsoft_timepicker.active .xdsoft_time.xdsoft_current').click
     end
 
     it 'can set birthday'  do

--- a/spec/filter_form_spec.rb
+++ b/spec/filter_form_spec.rb
@@ -1,5 +1,15 @@
 require 'spec_helper'
 
+def pick_date(input_selector, date_num)
+  page.find(input_selector).click
+  sleep 0.3
+  picker = page.find('.xdsoft_datetimepicker', visible: true)
+  picker.find(".xdsoft_calendar td.xdsoft_date[data-date=\"#{date_num}\"]", match: :first).click
+  sleep 0.2
+  picker.find('.xdsoft_timepicker.active .xdsoft_time.xdsoft_current').click
+  sleep 0.2
+end
+
 describe 'authors index', type: :feature, js: true do
   before do
     add_author_resource
@@ -12,19 +22,8 @@ describe 'authors index', type: :feature, js: true do
 
     context 'filter by Date column' do
       before do
-        page.find('input#q_birthday_gteq').click
-
-        page.find('.xdsoft_datetimepicker', visible: true)
-            .find('.xdsoft_calendar td.xdsoft_date[data-date="1"]').click
-        page.find('.xdsoft_datetimepicker', visible: true)
-            .find('.xdsoft_timepicker.active .xdsoft_time.xdsoft_current').click
-
-        page.find('input#q_birthday_lteq').click
-
-        page.find('.xdsoft_datetimepicker', visible: true)
-          .find('.xdsoft_calendar td.xdsoft_date[data-date="20"]').click
-        page.find('.xdsoft_datetimepicker', visible: true)
-            .find('.xdsoft_timepicker.active .xdsoft_time.xdsoft_current').click
+        pick_date('input#q_birthday_gteq', 1)
+        pick_date('input#q_birthday_lteq', 20)
       end
 
       it 'can set date from/to' do
@@ -55,21 +54,8 @@ describe 'authors index', type: :feature, js: true do
                        last_name: "from-the-future",
                        created_at: (Time.now.change(day: 20) + 2.hours).to_formatted_s(:db))
 
-        # chose 01 and 20 day of the current month
-
-        page.find('input#q_created_at_gteq_datetime_picker').click
-
-        page.find('.xdsoft_datetimepicker', visible: true)
-            .find('.xdsoft_calendar td.xdsoft_date[data-date="1"]').click
-        page.find('.xdsoft_datetimepicker', visible: true)
-            .find('.xdsoft_timepicker.active .xdsoft_time.xdsoft_current').click
-
-        page.find('input#q_created_at_lteq_datetime_picker').click
-
-        page.find('.xdsoft_datetimepicker', visible: true)
-          .find('.xdsoft_calendar td.xdsoft_date[data-date="20"]').click
-        page.find('.xdsoft_datetimepicker', visible: true)
-            .find('.xdsoft_timepicker.active .xdsoft_time.xdsoft_current').click
+        pick_date('input#q_created_at_gteq_datetime_picker', 1)
+        pick_date('input#q_created_at_lteq_datetime_picker', 20)
 
         @value_from = page.find('#q_created_at_gteq_datetime_picker').value
         @value_to = page.find('#q_created_at_lteq_datetime_picker').value
@@ -99,18 +85,8 @@ describe 'authors index', type: :feature, js: true do
         Author.create!(name: 'Ron', last_name: 'Two', updated_at: (Time.now.change(day: 20) - 1.hour).to_formatted_s(:db))
         Author.create!(name: 'Rey', last_name: 'future', updated_at: Time.now.change(day: 21).to_formatted_s(:db))
 
-        # chose 01 and 20 day of the current month
-        page.find('input#q_last_seen_at_gteq_datetime_picker').click
-        page.find('.xdsoft_datetimepicker', visible: true)
-            .find('.xdsoft_calendar td.xdsoft_date[data-date="1"]').click
-        page.find('.xdsoft_datetimepicker', visible: true)
-            .find('.xdsoft_timepicker.active .xdsoft_time.xdsoft_current').click
-
-        page.find('input#q_last_seen_at_lteq_datetime_picker').click
-        page.find('.xdsoft_datetimepicker', visible: true)
-            .find('.xdsoft_calendar td.xdsoft_date[data-date="20"]').click
-        page.find('.xdsoft_datetimepicker', visible: true)
-            .find('.xdsoft_timepicker.active .xdsoft_time.xdsoft_current').click
+        pick_date('input#q_last_seen_at_gteq_datetime_picker', 1)
+        pick_date('input#q_last_seen_at_lteq_datetime_picker', 20)
 
         @value_from = page.find('#q_last_seen_at_gteq_datetime_picker').value
         @value_to = page.find('#q_last_seen_at_lteq_datetime_picker').value

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
-require 'coveralls'
-Coveralls.wear!
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/spec/'
+end
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH << File.expand_path('../support', __FILE__)
@@ -33,8 +35,6 @@ ActiveAdmin.application.current_user_method = false
 require 'rspec/rails'
 require 'capybara/rails'
 require 'capybara/rspec'
-require 'selenium-webdriver'
-
 require 'support/admin'
 require 'support/capybara'
 
@@ -42,6 +42,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
+    ActiveRecord::Migration.maintain_test_schema!
     DatabaseCleaner.strategy = :truncation
     DatabaseCleaner.clean_with(:truncation)
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,14 +1,8 @@
+require 'capybara/cuprite'
+
 Capybara.server = :webrick
-
-Capybara.configure do |config|
-  config.match = :prefer_exact
+Capybara.register_driver :cuprite do |app|
+  Capybara::Cuprite::Driver.new(app, headless: true, window_size: [1280, 800])
 end
-
-Capybara.register_driver :selenium_chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(
-    args: %w[headless disable-gpu no-sandbox]
-  )
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
-end
-
-Capybara.javascript_driver = :selenium_chrome
+Capybara.javascript_driver = :cuprite
+Capybara.default_max_wait_time = 5

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -1,7 +1,12 @@
 # Rails template to build the sample app for specs
 
-generate :model, 'author name:string{10}:uniq last_name:string birthday:date'
-generate :model, 'post title:string:uniq body:text author:references'
+# Ensure Sprockets manifest exists (required by Rails 8+)
+FileUtils.mkdir_p("app/assets/config")
+File.write("app/assets/config/manifest.js",
+  "//= link_directory ../javascripts .js\n//= link_directory ../stylesheets .css\n")
+
+generate :model, 'author name:string{10}:uniq last_name:string birthday:date --force'
+generate :model, 'post title:string:uniq body:text author:references --force'
 
 # Compatibility with old ransack
 inject_into_file "app/models/application_record.rb", after: "primary_abstract_class\n" do
@@ -47,24 +52,17 @@ inject_into_file "app/models/author.rb", after: "ApplicationRecord\n" do
   STRING
 end
 
-# Configure default_url_options in test environment
-inject_into_file "config/environments/test.rb", after: "config.cache_classes = true\n" do
-  "  config.action_mailer.default_url_options = { :host => 'example.com' }\n"
-end
-
-# Add our local Active Admin to the load path
-inject_into_file "config/environment.rb", after: "require File.expand_path('../application', __FILE__)" do
-  "\n$LOAD_PATH.unshift('#{File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib'))}')\nrequire \"active_admin\"\n"
-end
-
-run "rm Gemfile"
+# Add our local Active Admin to the load path (Rails 7.1+ uses require_relative)
+gsub_file "config/environment.rb",
+  'require_relative "application"',
+  "require_relative \"application\"\n$LOAD_PATH.unshift('#{File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib'))}')\nrequire \"active_admin\"\n"
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 generate :'active_admin:install --skip-users'
 generate :'formtastic:install'
 
-# Install active_admin_date_time_datetimepicker assets
+# Install active_admin_datetimepicker assets
 inject_into_file "app/assets/stylesheets/active_admin.scss" do
   "@import \"active_admin_datetimepicker\";\n"
 end
@@ -73,9 +71,9 @@ inject_into_file "app/assets/javascripts/active_admin.js" do
   "//= require active_admin_datetimepicker\n"
 end
 
-run "rm -r test"
-run "rm -r spec"
-
+run "rm -rf test"
 route "root :to => 'admin/dashboard#index'"
-
 rake "db:migrate"
+
+# Remove Gemfile last so rake/route/generate work during template
+run "rm -f Gemfile Gemfile.lock"


### PR DESCRIPTION
- Drop Ruby < 3.1, Rails < 7.1, ActiveAdmin < 3.0
- Replace selenium-webdriver/webdrivers with Cuprite
- Replace coveralls with direct test runs
- Update sqlite3 ~> 1.4 to ~> 2.0
- Move sprockets-rails/sass-rails out of test group
- Fix rails_template.rb for Rails 7.1+ (require_relative)
- Fix ambiguous calendar selectors for Cuprite
- Add ActiveRecord::Migration.maintain_test_schema!
- Update CI matrix: Ruby 3.2-3.4, Rails 7.1-7.2, AA 3.2-3.3
- Use bundler-cache in CI, remove bundler < 2 constraint